### PR TITLE
debug output based on ns-3 logging makros fixed

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -68,7 +68,9 @@ project "ns3-federate"
                      }
 
    filter "configurations:Debug"
-      defines { "DEBUG" }
+      defines { "DEBUG"
+              , "NS3_LOG_ENABLE"
+              , "NS3_ASSERT_ENABLE" }
       symbols "On"
       links { "ns" .. ns3version .. "-antenna-debug"
 --            , "ns" .. ns3version .. "-aodv-debug"


### PR DESCRIPTION
# Bugfix
## Issue
log messages created by ns-3 macros in the federate are deactivated
## Changes
- compiler parameters added which define `NS3_LOG_ENABLE` and `NS3_ASSERT_ENABLE` for debug build
## Test / Result
- release build has no logging enabled
- premake5 runs successfully
- additional log entries are configurable by configuration file (ex.: `ns3_federate_config.xml`)