### PR TITLE
197 txpower: int -> double

### DIFF
--- a/ClientServerChannelMessages.proto
+++ b/ClientServerChannelMessages.proto
@@ -114,7 +114,7 @@ message ConfigureRadioMessage {
 		required bool receiving_messages = 1; //Determines whether the radio receives messages or only routes
 		required uint32 ip_address = 2;
 		required uint32 subnet_address = 3;
-		required uint32 transmission_power = 4;
+		required double transmission_power = 4;
 		enum RadioMode {
 			SINGLE_CHANNEL = 1;
 			DUAL_CHANNEL = 2;

--- a/src/ClientServerChannel.h
+++ b/src/ClientServerChannel.h
@@ -101,7 +101,7 @@ struct CSC_radio_config{
 	bool turnedOn;
 	uint32_t ip_address;
 	uint32_t subnet;
-	int tx_power;
+	double tx_power;
 	CHANNEL_MODE channelmode;
 	RADIO_CHANNEL primary_channel;
 	RADIO_CHANNEL secondary_channel;

--- a/src/mosaic-node-manager.cc
+++ b/src/mosaic-node-manager.cc
@@ -152,7 +152,7 @@ namespace ns3 {
         m_isDeactivated[nodeId] = true;
     }
 
-    void MosaicNodeManager::ConfigureNodeRadio(uint32_t nodeId, bool radioTurnedOn, int transmitPower) {
+    void MosaicNodeManager::ConfigureNodeRadio(uint32_t nodeId, bool radioTurnedOn, double transmitPower) {
         if (m_isDeactivated[nodeId]) {
             return;
         }
@@ -175,7 +175,7 @@ namespace ns3 {
                 }                        
                 Ptr<YansWifiPhy> wavePhy = DynamicCast<YansWifiPhy> (netDev->GetPhy());
                 if (wavePhy != 0) {
-                    double txDBm = 10 * log10((double) transmitPower);
+                    double txDBm = 10 * log10(transmitPower);
                     wavePhy->SetTxPowerStart(txDBm);
                     wavePhy->SetTxPowerEnd(txDBm);
                 }

--- a/src/mosaic-node-manager.h
+++ b/src/mosaic-node-manager.h
@@ -60,7 +60,7 @@ namespace ns3 {
         /**
          * @brief Evaluates configuration message and applies it to the node
          */
-        void ConfigureNodeRadio(uint32_t nodeId, bool radioTurnedOn, int transmitPower);
+        void ConfigureNodeRadio(uint32_t nodeId, bool radioTurnedOn, double transmitPower);
 
         void SendMsg(uint32_t nodeId, uint32_t protocolID, uint32_t msgID, uint32_t payLenght, Ipv4Address ipv4Add);
 

--- a/src/mosaic-ns3-server.cc
+++ b/src/mosaic-ns3-server.cc
@@ -176,7 +176,7 @@ namespace ns3 {
                     ambassadorFederateChannel.readConfigurationMessage(config_message);
                     Time tNext = NanoSeconds(config_message.time);
                     Time tDelay = tNext - sim->Now();
-                    int transmitPower = -1;
+                    double transmitPower = -1;
                     bool radioTurnedOn = false;
                     if (config_message.num_radios == SINGLE_RADIO) {
                         radioTurnedOn = true; //other modes currently not supported, other modes turn off radio


### PR DESCRIPTION
## Description
- ClientServerChannel protocol changed:
  - `transmission_power` type change from `uint32` to `double`
- this PR is interlocked with OMNeT++ federate, MOSAIC and an internal repository

## Related Issue
- internal issue 197