### PR TITLE
redirection: std::clog -> std::cout

### DIFF
--- a/src/mosaic_starter.cc
+++ b/src/mosaic_starter.cc
@@ -139,8 +139,19 @@ void SetLogLevels(const std::string & configFile) {
     xmlXPathFreeObject(result);
 }
 
+void redirectClogToCout() {
+    // std::clog should print to standard output (std::cout)
+    // change stream buffer of std::clog
+    auto destination = std::cout.rdbuf();
+    std::clog.rdbuf(destination);
+}
+
 int main(int argc, char *argv[]) {
     using namespace std;
+
+    // ns3 logs to std::clog, redirect to std::cout
+    redirectClogToCout();
+
     //default values
     int port = 0;
     int cmdPort = 0;


### PR DESCRIPTION
# Description
- output of ns-3 log functions redirected to standard output
  - ns-3 logs to `std::clog`, which prints to error output
  - stream `std::clog` is redirected to `std::cout`

# Related Issues
- internal

# Example
## Excerpt from `CommunicationDetails.log`
### std::clog -> error output
```
2021-09-28 17:27:01,965 ERROR Ns3Error - Process Ns3 : +0.000000000s [DEBUG] Saving frequency configuration for initialization
```
### std::clog -> standard output
```
2021-10-01 15:15:51,293 INFO  Ns3Output - Process Ns3 : +0.000000000s [DEBUG] Saving frequency configuration for initialization
```