### PR TITLE
fix: ns3 server should not close itself

### DIFF
--- a/src/mosaic-ns3-server.cc
+++ b/src/mosaic-ns3-server.cc
@@ -71,10 +71,6 @@ namespace ns3 {
         std::cout << "ns3Server: created new connection to " << port << std::endl;
     }
 
-    void MosaicNs3Server::Init() {
-        NS_LOG_INFO("ns-3 server --> Starting event handling .... ");
-    }
-
     void MosaicNs3Server::processCommandsUntilSimStep() {
         try {
             if (m_closeConnection) {

--- a/src/mosaic-ns3-server.cc
+++ b/src/mosaic-ns3-server.cc
@@ -77,18 +77,12 @@ namespace ns3 {
 
     void MosaicNs3Server::processCommandsUntilSimStep() {
         try {
-            if (!m_closeConnection) {
-
-                Ptr<MosaicSimulatorImpl> Sim = DynamicCast<MosaicSimulatorImpl> (Simulator::GetImplementation());
-                Sim->AttachNS3Server(this);
-
-                //create the dummy event (start of the simulation) to avoid an empty event-list
-                //NS3 will throw an exception if the event-list is empty
-                Time tNext = NanoSeconds(m_startTime);
-                Simulator::Schedule(tNext, &MosaicNs3Server::Init, this);
-            } else {
-                return;
+            if (m_closeConnection) {
+                return;                
             }
+
+            Ptr<MosaicSimulatorImpl> sim = DynamicCast<MosaicSimulatorImpl> (Simulator::GetImplementation());
+            sim->AttachNS3Server(this);
 
             while (!m_closeConnection) {
                 NS_LOG_INFO("NumberOfNodes= " << ns3::NodeList::GetNNodes());

--- a/src/mosaic-ns3-server.cc
+++ b/src/mosaic-ns3-server.cc
@@ -71,6 +71,10 @@ namespace ns3 {
         std::cout << "ns3Server: created new connection to " << port << std::endl;
     }
 
+    void MosaicNs3Server::Init() {
+        NS_LOG_INFO("ns-3 server --> Starting event handling .... ");
+    }
+
     void MosaicNs3Server::processCommandsUntilSimStep() {
         try {
             if (!m_closeConnection) {
@@ -78,10 +82,10 @@ namespace ns3 {
                 Ptr<MosaicSimulatorImpl> Sim = DynamicCast<MosaicSimulatorImpl> (Simulator::GetImplementation());
                 Sim->AttachNS3Server(this);
 
-                //create the dummy event (end of the simulation) to avoid a empty event-list
+                //create the dummy event (start of the simulation) to avoid an empty event-list
                 //NS3 will throw an exception if the event-list is empty
-                Time tNext = NanoSeconds(m_endTime);
-                Simulator::Schedule(tNext, &MosaicNs3Server::Close, this);
+                Time tNext = NanoSeconds(m_startTime);
+                Simulator::Schedule(tNext, &MosaicNs3Server::Init, this);
             } else {
                 return;
             }

--- a/src/mosaic-ns3-server.h
+++ b/src/mosaic-ns3-server.h
@@ -121,6 +121,8 @@ namespace ns3 {
          */
         void CreateNode(int ID, int posx, int posy);
 
+        void Init();
+
         void Close();
 
         void DeactivateNode(uint32_t nodeId);

--- a/src/mosaic-ns3-server.h
+++ b/src/mosaic-ns3-server.h
@@ -121,8 +121,6 @@ namespace ns3 {
          */
         void CreateNode(int ID, int posx, int posy);
 
-        void Init();
-
         void Close();
 
         void DeactivateNode(uint32_t nodeId);


### PR DESCRIPTION
`ns3_server` does not close itself anymore when the end of the simulation is reached. Instead, the server is closed only from external calls, such as MOSAICs `Ns3Ambassador`. Especially due to a change introduced by https://github.com/eclipse/mosaic/pull/295, the `ns3_server` would close too early since the endtime is now a valid timestep. In earlier versions of ns3, at least one event was required to be in the event queue on start up. This is not the case anymore and we can safely delete this. 